### PR TITLE
Add Riot API template project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 # SDCStatsv2
+
+This repository provides a simple Python template for fetching match data from the Riot Games API.  
+You can supply your Riot API key via the `RIOT_API_KEY` environment variable or with the `--api-key` command line flag.
+
+## Setup
+
+1. Create a Python virtual environment (optional but recommended).
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+Run the `main.py` script with a region code and one or more match IDs. For example:
+
+```bash
+python main.py na1 <match_id1> <match_id2>
+```
+
+Replace `<match_id1>` and `<match_id2>` with the match IDs you want to fetch. You can also specify `--output mydata.json` to write the results to a file.
+
+## Example
+
+```bash
+export RIOT_API_KEY=your_api_key_here
+python main.py na1 ABCDEFGHIJKLMN
+```
+
+This will print the JSON match data for the given match ID to stdout.
+
+## Notes
+
+- Custom games can be queried the same way as any other match. Once you have the match ID(s) for your custom games, pass them to `main.py`.
+- This template focuses on fetching match data. You can extend it to store results in a database or perform any additional analysis you need.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+from typing import List
+
+from riot_api import RiotAPI
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fetch League of Legends match data")
+    parser.add_argument("region", help="Riot region, e.g. na1, euw1")
+    parser.add_argument("match_ids", nargs="+", help="Match IDs to fetch")
+    parser.add_argument("--api-key", help="Riot API key; otherwise uses RIOT_API_KEY env var")
+    parser.add_argument("--output", help="Output JSON file (default: stdout)")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    api = RiotAPI(api_key=args.api_key)
+
+    matches: List[dict] = []
+    for match_id in args.match_ids:
+        data = api.get_match(args.region, match_id)
+        matches.append(data)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            json.dump(matches, f, indent=2)
+    else:
+        print(json.dumps(matches, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/riot_api/__init__.py
+++ b/riot_api/__init__.py
@@ -1,0 +1,3 @@
+from .riot_api import RiotAPI
+
+__all__ = ["RiotAPI"]

--- a/riot_api/riot_api.py
+++ b/riot_api/riot_api.py
@@ -1,0 +1,23 @@
+import os
+from typing import Dict, Any
+
+import requests
+
+
+class RiotAPI:
+    """Simple wrapper around the Riot Games API."""
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.environ.get("RIOT_API_KEY")
+        if not self.api_key:
+            raise ValueError("Riot API key must be provided via argument or RIOT_API_KEY env var")
+
+    def _headers(self) -> Dict[str, str]:
+        return {"X-Riot-Token": self.api_key}
+
+    def get_match(self, region: str, match_id: str) -> Dict[str, Any]:
+        """Fetch match data from the Riot API."""
+        url = f"https://{region}.api.riotgames.com/lol/match/v5/matches/{match_id}"
+        resp = requests.get(url, headers=self._headers(), timeout=10)
+        resp.raise_for_status()
+        return resp.json()


### PR DESCRIPTION
## Summary
- basic template for fetching League of Legends match data via Riot API
- CLI `main.py` script to fetch and optionally save match JSON
- `riot_api` module provides `RiotAPI` class
- document setup and usage in README
- list `requests` as requirement

## Testing
- `python -m py_compile main.py riot_api/riot_api.py`