### PR TITLE
Add player profile web app with mock data

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+flask

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,27 @@
+from flask import Flask, render_template, jsonify
+import json
+import os
+
+app = Flask(__name__)
+
+MOCK_DATA_PATH = os.path.join(os.path.dirname(__file__), 'mock_data.json')
+
+
+def load_data():
+    with open(MOCK_DATA_PATH, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/api/profile')
+def profile_data():
+    data = load_data()
+    return jsonify(data)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/mock_data.json
+++ b/webapp/mock_data.json
@@ -1,0 +1,72 @@
+{
+  "player": {
+    "name": "Summoner1",
+    "general": {
+      "winRate": 55.2,
+      "kda": "3.2",
+      "cs": 175.3,
+      "gold": 14250,
+      "damage": 21500
+    },
+    "champions": [
+      {
+        "name": "Aatrox",
+        "games": 10,
+        "winRate": 60.0,
+        "kda": "3.5",
+        "cs": 180.1,
+        "gold": 14500
+      },
+      {
+        "name": "Ahri",
+        "games": 8,
+        "winRate": 50.0,
+        "kda": "2.8",
+        "cs": 170.3,
+        "gold": 13800
+      },
+      {
+        "name": "Jinx",
+        "games": 5,
+        "winRate": 40.0,
+        "kda": "2.1",
+        "cs": 190.4,
+        "gold": 15000
+      }
+    ],
+    "matches": [
+      {
+        "date": "2023-05-01",
+        "opponent": "PlayerA",
+        "result": "Win"
+      },
+      {
+        "date": "2023-05-02",
+        "opponent": "PlayerB",
+        "result": "Loss"
+      },
+      {
+        "date": "2023-05-03",
+        "opponent": "PlayerC",
+        "result": "Win"
+      }
+    ],
+    "winRateHistory": [
+      {"date": "2023-04-01", "winRate": 52},
+      {"date": "2023-05-01", "winRate": 55},
+      {"date": "2023-06-01", "winRate": 57}
+    ],
+    "roleDistribution": {
+      "Top": 40,
+      "Jungle": 30,
+      "Mid": 10,
+      "ADC": 15,
+      "Support": 5
+    },
+    "objectiveControl": {
+      "dragons": 5,
+      "barons": 2,
+      "towers": 25
+    }
+  }
+}

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,0 +1,96 @@
+function renderGeneral(data) {
+  const container = document.getElementById('general');
+  container.innerHTML = `
+    <table class="table table-bordered table-custom">
+      <tbody>
+        <tr><th>Win Rate</th><td>${data.winRate}%</td></tr>
+        <tr><th>KDA Ratio</th><td>${data.kda}</td></tr>
+        <tr><th>Average CS</th><td>${data.cs}</td></tr>
+        <tr><th>Gold Earned</th><td>${data.gold}</td></tr>
+        <tr><th>Damage Dealt</th><td>${data.damage}</td></tr>
+      </tbody>
+    </table>`;
+}
+
+function renderChampions(champs) {
+  const container = document.getElementById('champions');
+  let rows = champs.map(c => `
+    <tr>
+      <td>${c.name}</td>
+      <td>${c.games}</td>
+      <td>${c.winRate}%</td>
+      <td>${c.kda}</td>
+      <td>${c.cs}</td>
+      <td>${c.gold}</td>
+    </tr>`).join('');
+  container.innerHTML = `
+    <table class="table table-striped table-custom">
+      <thead>
+        <tr>
+          <th>Champion</th><th>Games</th><th>Win Rate</th><th>KDA</th><th>CS</th><th>Gold</th>
+        </tr>
+      </thead>
+      <tbody>${rows}</tbody>
+    </table>`;
+}
+
+function renderStats(data) {
+  const container = document.getElementById('stats');
+  let matchRows = data.matches.map(m => `
+    <tr><td>${m.date}</td><td>${m.opponent}</td><td>${m.result}</td></tr>`).join('');
+  container.innerHTML = `
+    <h4>Recent Matches</h4>
+    <table class="table table-bordered table-custom mb-4">
+      <thead><tr><th>Date</th><th>Opponent</th><th>Result</th></tr></thead>
+      <tbody>${matchRows}</tbody>
+    </table>
+    <h4>Performance Trends</h4>
+    <canvas id="winRateChart" height="100"></canvas>
+    <h4 class="mt-4">Role Distribution</h4>
+    <canvas id="roleChart" height="100"></canvas>
+    <h4 class="mt-4">Objective Control</h4>
+    <ul>
+      <li>Dragons: ${data.objectiveControl.dragons}</li>
+      <li>Barons: ${data.objectiveControl.barons}</li>
+      <li>Towers: ${data.objectiveControl.towers}</li>
+    </ul>`;
+  renderCharts(data);
+}
+
+function renderCharts(data) {
+  const winCtx = document.getElementById('winRateChart').getContext('2d');
+  new Chart(winCtx, {
+    type: 'line',
+    data: {
+      labels: data.winRateHistory.map(p => p.date),
+      datasets: [{
+        label: 'Win Rate',
+        data: data.winRateHistory.map(p => p.winRate),
+        borderColor: 'blue',
+        fill: false
+      }]
+    },
+    options: {scales: {y: {min: 0, max: 100}}}
+  });
+
+  const roleCtx = document.getElementById('roleChart').getContext('2d');
+  new Chart(roleCtx, {
+    type: 'pie',
+    data: {
+      labels: Object.keys(data.roleDistribution),
+      datasets: [{
+        data: Object.values(data.roleDistribution),
+        backgroundColor: ['red','green','blue','orange','purple']
+      }]
+    }
+  });
+}
+
+fetch('/api/profile')
+  .then(r => r.json())
+  .then(data => {
+    const p = data.player;
+    renderGeneral(p.general);
+    renderChampions(p.champions);
+    renderStats(p);
+  });

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,0 +1,3 @@
+.table-custom th, .table-custom td {
+  vertical-align: middle;
+}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -1,0 +1,21 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+<h1 class="mb-4">Player Profile</h1>
+<ul class="nav nav-tabs" id="profileTabs" role="tablist">
+  <li class="nav-item" role="presentation">
+    <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab">General</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="champions-tab" data-bs-toggle="tab" data-bs-target="#champions" type="button" role="tab">Champions</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="stats-tab" data-bs-toggle="tab" data-bs-target="#stats" type="button" role="tab">Stats</button>
+  </li>
+</ul>
+<div class="tab-content mt-3">
+  <div class="tab-pane fade show active" id="general" role="tabpanel"></div>
+  <div class="tab-pane fade" id="champions" role="tabpanel"></div>
+  <div class="tab-pane fade" id="stats" role="tabpanel"></div>
+</div>
+{% endblock %}

--- a/webapp/templates/layout.html
+++ b/webapp/templates/layout.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SDCStats Player Profile</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+  <div class="container my-4">
+    {% block content %}{% endblock %}
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask dependency
- create Flask app serving player profile
- implement HTML templates for General, Champions, and Stats tabs
- add JS to populate UI with mock data and render charts
- provide sample mock data

## Testing
- `python -m py_compile webapp/app.py main.py riot_api/riot_api.py`
