### PR TITLE
Enhance match view with scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ real Riot API.
 
 3. Open `http://127.0.0.1:5000/` in your browser. Enter a region and match ID to
    fetch the match data from the Riot API.
+
+The homepage now renders a simple scoreboard for each team, similar to popular
+match history sites. Player names, champions, K/D/A and creep score are shown in
+tables after the match data is fetched.

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,3 +1,43 @@
+const scoreboard = document.getElementById('scoreboard');
+
+function displayScoreboard(data) {
+  scoreboard.innerHTML = '';
+  if (!data.info || !Array.isArray(data.info.participants)) {
+    scoreboard.textContent = 'Unexpected match data';
+    return;
+  }
+
+  const teams = { 100: [], 200: [] };
+  data.info.participants.forEach(p => {
+    teams[p.teamId].push(p);
+  });
+
+  Object.entries(teams).forEach(([teamId, players]) => {
+    const header = document.createElement('h3');
+    header.textContent = teamId === '100' ? 'Blue Team' : 'Red Team';
+    scoreboard.appendChild(header);
+
+    const table = document.createElement('table');
+    table.className = 'table table-custom table-striped mb-4';
+
+    const thead = document.createElement('thead');
+    thead.innerHTML = '<tr><th>Summoner</th><th>Champion</th><th>K / D / A</th><th>CS</th></tr>';
+    table.appendChild(thead);
+
+    const tbody = document.createElement('tbody');
+    players.forEach(p => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${p.summonerName}</td>` +
+                      `<td>${p.championName}</td>` +
+                      `<td>${p.kills} / ${p.deaths} / ${p.assists}</td>` +
+                      `<td>${p.totalMinionsKilled}</td>`;
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    scoreboard.appendChild(table);
+  });
+}
+
 document.getElementById('matchForm').addEventListener('submit', function(e) {
   e.preventDefault();
   const region = document.getElementById('region').value;
@@ -8,10 +48,16 @@ document.getElementById('matchForm').addEventListener('submit', function(e) {
     return;
   }
   output.textContent = 'Loading...';
+  scoreboard.innerHTML = '';
   fetch(`/api/match?region=${encodeURIComponent(region)}&match_id=${encodeURIComponent(matchId)}`)
     .then(r => r.json())
     .then(data => {
-      output.textContent = JSON.stringify(data, null, 2);
+      output.textContent = '';
+      if (data.error) {
+        output.textContent = 'Error: ' + data.error;
+        return;
+      }
+      displayScoreboard(data);
     })
     .catch(err => {
       output.textContent = 'Error: ' + err;

--- a/webapp/static/style.css
+++ b/webapp/static/style.css
@@ -1,3 +1,7 @@
 .table-custom th, .table-custom td {
   vertical-align: middle;
 }
+
+#scoreboard {
+  overflow-x: auto;
+}

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -16,4 +16,5 @@
   </div>
 </form>
 <pre id="matchOutput"></pre>
+<div id="scoreboard"></div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- show a table scoreboard per team in the web UI
- add minimal styling and JS logic for scoreboard
- document the new scoreboard view in README

## Testing
- `python -m py_compile main.py webapp/app.py riot_api/riot_api.py`
- `python -m webapp.app` *(fails: ModuleNotFoundError: No module named 'flask')*