### PR TITLE
Add player lookup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ real Riot API.
 The homepage now renders a scoreboard for each team, similar to popular match
 history sites. Player names, champion icons, K/D/A, creep score and item builds
 are shown in tables after the match data is fetched.
+
+There is also a Player Lookup page at `/player` where you can enter a region and
+a Riot ID (`name#TAG`). The app fetches the last 10 games for that player and
+displays basic stats for each match.

--- a/riot_api/riot_api.py
+++ b/riot_api/riot_api.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Any
+from typing import Dict, Any, List
 
 import requests
 
@@ -12,12 +12,51 @@ class RiotAPI:
         if not self.api_key:
             raise ValueError("Riot API key must be provided via argument or RIOT_API_KEY env var")
 
+        self._region_map = {
+            # Americas routing group
+            "na1": "americas",
+            "br1": "americas",
+            "la1": "americas",
+            "la2": "americas",
+            "oc1": "americas",
+            # Europe routing group
+            "euw1": "europe",
+            "eun1": "europe",
+            "tr1": "europe",
+            "ru": "europe",
+            # Asia routing group
+            "kr": "asia",
+            "jp1": "asia",
+        }
+
     def _headers(self) -> Dict[str, str]:
         return {"X-Riot-Token": self.api_key}
+
+    def _cluster(self, region: str) -> str:
+        """Map a platform region (e.g. na1) to its routing cluster."""
+        return self._region_map.get(region.lower(), region)
 
     def get_match(self, region: str, match_id: str) -> Dict[str, Any]:
         """Fetch match data from the Riot API."""
         url = f"https://{region}.api.riotgames.com/lol/match/v5/matches/{match_id}"
+        resp = requests.get(url, headers=self._headers(), timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_account_by_riot_id(self, game_name: str, tag_line: str) -> Dict[str, Any]:
+        """Fetch account information using Riot ID."""
+        url = f"https://americas.api.riotgames.com/riot/account/v1/accounts/by-riot-id/{game_name}/{tag_line}"
+        resp = requests.get(url, headers=self._headers(), timeout=10)
+        resp.raise_for_status()
+        return resp.json()
+
+    def get_matches_for_puuid(self, region: str, puuid: str, count: int = 10) -> List[str]:
+        """Return a list of recent match IDs for the given player."""
+        cluster = self._cluster(region)
+        url = (
+            f"https://{cluster}.api.riotgames.com/lol/match/v5/matches/by-puuid/{puuid}/ids"
+            f"?start=0&count={count}"
+        )
         resp = requests.get(url, headers=self._headers(), timeout=10)
         resp.raise_for_status()
         return resp.json()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -25,6 +25,12 @@ def index():
     return render_template('index.html')
 
 
+@app.route('/player')
+def player_page():
+    """Render the player lookup page."""
+    return render_template('player.html')
+
+
 @app.route('/api/match')
 def match_data():
     match_id = request.args.get('match_id')
@@ -36,6 +42,42 @@ def match_data():
     except Exception as e:
         return jsonify({'error': str(e)}), 500
     return jsonify(data)
+
+
+@app.route('/api/player')
+def player_data():
+    riot_id = request.args.get('riot_id')
+    region = request.args.get('region')
+    if not riot_id or not region:
+        return jsonify({'error': 'riot_id and region parameters are required'}), 400
+    if '#' not in riot_id:
+        return jsonify({'error': 'riot_id must be in the form name#TAG'}), 400
+
+    game_name, tag_line = riot_id.split('#', 1)
+    try:
+        account = api.get_account_by_riot_id(game_name, tag_line)
+        puuid = account['puuid']
+        match_ids = api.get_matches_for_puuid(region, puuid, count=10)
+        matches = []
+        for mid in match_ids:
+            match = api.get_match(api._cluster(region), mid)
+            participant = next(
+                (p for p in match.get('info', {}).get('participants', []) if p.get('puuid') == puuid),
+                None,
+            )
+            if participant:
+                matches.append({
+                    'match_id': mid,
+                    'champion': participant.get('championName'),
+                    'kills': participant.get('kills'),
+                    'deaths': participant.get('deaths'),
+                    'assists': participant.get('assists'),
+                    'win': participant.get('win'),
+                })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+    return jsonify({'matches': matches})
 
 
 if __name__ == '__main__':

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -74,3 +74,59 @@ document.getElementById('matchForm').addEventListener('submit', function(e) {
       output.textContent = 'Error: ' + err;
     });
 });
+
+const matchesEl = document.getElementById('matches');
+
+function displayMatches(data) {
+  matchesEl.innerHTML = '';
+  if (!data.matches || !Array.isArray(data.matches)) {
+    matchesEl.textContent = 'Unexpected player data';
+    return;
+  }
+
+  const table = document.createElement('table');
+  table.className = 'table table-custom table-striped';
+  table.innerHTML = '<thead><tr><th>Match ID</th><th>Champion</th><th>K / D / A</th><th>Result</th></tr></thead>';
+
+  const tbody = document.createElement('tbody');
+  data.matches.forEach(m => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${m.match_id}</td>` +
+                    `<td>${m.champion}</td>` +
+                    `<td>${m.kills} / ${m.deaths} / ${m.assists}</td>` +
+                    `<td>${m.win ? 'Win' : 'Loss'}</td>`;
+    tbody.appendChild(row);
+  });
+
+  table.appendChild(tbody);
+  matchesEl.appendChild(table);
+}
+
+const playerForm = document.getElementById('playerForm');
+if (playerForm) {
+  playerForm.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const region = document.getElementById('playerRegion').value;
+    const riotId = document.getElementById('riotId').value.trim();
+    const out = document.getElementById('playerOutput');
+    if (!region || !riotId) {
+      out.textContent = 'Region and Riot ID are required';
+      return;
+    }
+    out.textContent = 'Loading...';
+    matchesEl.innerHTML = '';
+    fetch(`/api/player?region=${encodeURIComponent(region)}&riot_id=${encodeURIComponent(riotId)}`)
+      .then(r => r.json())
+      .then(data => {
+        out.textContent = '';
+        if (data.error) {
+          out.textContent = 'Error: ' + data.error;
+          return;
+        }
+        displayMatches(data);
+      })
+      .catch(err => {
+        out.textContent = 'Error: ' + err;
+      });
+  });
+}

--- a/webapp/templates/player.html
+++ b/webapp/templates/player.html
@@ -1,0 +1,20 @@
+{% extends 'layout.html' %}
+
+{% block content %}
+<h1 class="mb-4">Player Lookup</h1>
+<form id="playerForm" class="mb-3">
+  <div class="row g-2">
+    <div class="col-auto">
+      <input type="text" class="form-control" id="playerRegion" placeholder="Region (na1)" value="na1">
+    </div>
+    <div class="col-auto">
+      <input type="text" class="form-control" id="riotId" placeholder="Riot ID (name#TAG)">
+    </div>
+    <div class="col-auto">
+      <button type="submit" class="btn btn-primary">Lookup</button>
+    </div>
+  </div>
+</form>
+<pre id="playerOutput"></pre>
+<div id="matches"></div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- support Riot API account and match list queries
- add `/player` route to look up the last 10 games for a Riot ID
- implement player page UI and client-side JS
- document new functionality

## Testing
- `pytest -q`