### PR TITLE
Add clickable links for players and matches

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -38,7 +38,8 @@ def match_data():
     if not match_id or not region:
         return jsonify({'error': 'match_id and region parameters are required'}), 400
     try:
-        data = api.get_match(region, match_id)
+        # Use the routing cluster (e.g. "americas") for match requests
+        data = api.get_match(api._cluster(region), match_id)
     except Exception as e:
         return jsonify({'error': str(e)}), 500
     return jsonify(data)

--- a/webapp/static/script.js
+++ b/webapp/static/script.js
@@ -1,6 +1,6 @@
 const scoreboard = document.getElementById('scoreboard');
 
-function displayScoreboard(data) {
+function displayScoreboard(data, region) {
   scoreboard.innerHTML = '';
   if (!data.info || !Array.isArray(data.info.participants)) {
     scoreboard.textContent = 'Unexpected match data';
@@ -36,7 +36,16 @@ function displayScoreboard(data) {
       const champImg = `<img class="champion-icon me-1" src="${champBase}${p.championName}.png" alt="${p.championName}">`;
       const items = [p.item0, p.item1, p.item2, p.item3, p.item4, p.item5];
       const itemImgs = items.map(id => id ? `<img class="item-icon me-1" src="${itemBase}${id}.png" alt="">` : '').join('');
-      row.innerHTML = `<td>${p.summonerName}</td>` +
+
+      const riotName = p.riotIdGameName || p.riotIdName;
+      const riotTag = p.riotIdTagline;
+      let summonerCell = p.summonerName;
+      if (riotName && riotTag) {
+        const riotId = `${riotName}#${riotTag}`;
+        summonerCell = `<a href="/player?region=${encodeURIComponent(region)}&riot_id=${encodeURIComponent(riotId)}">${p.summonerName}</a>`;
+      }
+
+      row.innerHTML = `<td>${summonerCell}</td>` +
                       `<td>${champImg}${p.championName}</td>` +
                       `<td>${p.kills} / ${p.deaths} / ${p.assists}</td>` +
                       `<td>${p.totalMinionsKilled}</td>` +
@@ -70,7 +79,7 @@ if (matchForm) {
           output.textContent = 'Error: ' + data.error;
           return;
         }
-        displayScoreboard(data);
+        displayScoreboard(data, region);
       })
       .catch(err => {
         output.textContent = 'Error: ' + err;
@@ -80,7 +89,7 @@ if (matchForm) {
 
 const matchesEl = document.getElementById('matches');
 
-function displayMatches(data) {
+function displayMatches(data, region) {
   matchesEl.innerHTML = '';
   if (!data.matches || !Array.isArray(data.matches)) {
     matchesEl.textContent = 'Unexpected player data';
@@ -94,7 +103,8 @@ function displayMatches(data) {
   const tbody = document.createElement('tbody');
   data.matches.forEach(m => {
     const row = document.createElement('tr');
-    row.innerHTML = `<td>${m.match_id}</td>` +
+    const matchLink = `<a href="/?region=${encodeURIComponent(region)}&match_id=${encodeURIComponent(m.match_id)}">${m.match_id}</a>`;
+    row.innerHTML = `<td>${matchLink}</td>` +
                     `<td>${m.champion}</td>` +
                     `<td>${m.kills} / ${m.deaths} / ${m.assists}</td>` +
                     `<td>${m.win ? 'Win' : 'Loss'}</td>`;
@@ -126,10 +136,28 @@ if (playerForm) {
           out.textContent = 'Error: ' + data.error;
           return;
         }
-        displayMatches(data);
+        displayMatches(data, region);
       })
       .catch(err => {
         out.textContent = 'Error: ' + err;
       });
   });
 }
+
+// Auto-fetch data when query parameters are present
+document.addEventListener('DOMContentLoaded', function() {
+  const params = new URLSearchParams(window.location.search);
+  const regionParam = params.get('region');
+  const matchIdParam = params.get('match_id') || params.get('matchId');
+  if (matchForm && matchIdParam) {
+    if (regionParam) document.getElementById('region').value = regionParam;
+    document.getElementById('matchId').value = matchIdParam;
+    matchForm.dispatchEvent(new Event('submit'));
+  }
+  const riotIdParam = params.get('riot_id') || params.get('riotId');
+  if (playerForm && riotIdParam) {
+    if (regionParam) document.getElementById('playerRegion').value = regionParam;
+    document.getElementById('riotId').value = riotIdParam;
+    playerForm.dispatchEvent(new Event('submit'));
+  }
+});


### PR DESCRIPTION
## Summary
- make region cluster mapping used by match lookup API
- link player names on match page to player lookup
- link match IDs on player page to match lookup
- auto-trigger lookup when page URL includes query params

## Testing
- `python -m py_compile $(git ls-files '*.py')`