### PR TITLE
Add clickable links for players and matches

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -38,7 +38,8 @@ def match_data():
     if not match_id or not region:
         return jsonify({'error': 'match_id and region parameters are required'}), 400
     try:
-        data = api.get_match(region, match_id)
+        # Use the routing cluster (e.g. "americas") for match requests
+        data = api.get_match(api._cluster(region), match_id)
     except Exception as e:
         return jsonify({'error': str(e)}), 500
     return jsonify(data)


### PR DESCRIPTION
## Summary
- make region cluster mapping used by match lookup API
- link player names on match page to player lookup
- link match IDs on player page to match lookup
- auto-trigger lookup when page URL includes query params
- render scoreboard and match links using DOM nodes to ensure links display correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
