### PR TITLE
Add team color styling, rate limiter, and performance scores

### DIFF
--- a/src/RiotApi/RateLimiter.cs
+++ b/src/RiotApi/RateLimiter.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RiotApi;
+
+/// <summary>
+/// Simple rate limiter that enforces both a per-second and a per-two-minute limit.
+/// </summary>
+public class RateLimiter
+{
+    private readonly int _perSecond;
+    private readonly int _perTwoMinutes;
+    private readonly Queue<DateTime> _lastSecond = new();
+    private readonly Queue<DateTime> _lastTwoMinutes = new();
+    private readonly object _lock = new();
+
+    public RateLimiter(int perSecond, int perTwoMinutes)
+    {
+        _perSecond = perSecond;
+        _perTwoMinutes = perTwoMinutes;
+    }
+
+    public async Task WaitAsync()
+    {
+        while (true)
+        {
+            TimeSpan? delay = null;
+            lock (_lock)
+            {
+                var now = DateTime.UtcNow;
+                Cleanup(now);
+                if (_lastSecond.Count >= _perSecond)
+                {
+                    var diff = now - _lastSecond.Peek();
+                    if (diff.TotalSeconds < 1)
+                        delay = TimeSpan.FromSeconds(1) - diff;
+                }
+                if (!delay.HasValue && _lastTwoMinutes.Count >= _perTwoMinutes)
+                {
+                    var diff = now - _lastTwoMinutes.Peek();
+                    if (diff.TotalMinutes < 2)
+                        delay = TimeSpan.FromMinutes(2) - diff;
+                }
+                if (!delay.HasValue)
+                {
+                    _lastSecond.Enqueue(now);
+                    _lastTwoMinutes.Enqueue(now);
+                    return;
+                }
+            }
+            await Task.Delay(delay.Value);
+        }
+    }
+
+    private void Cleanup(DateTime now)
+    {
+        while (_lastSecond.Count > 0 && (now - _lastSecond.Peek()).TotalSeconds >= 1)
+            _lastSecond.Dequeue();
+        while (_lastTwoMinutes.Count > 0 && (now - _lastTwoMinutes.Peek()).TotalMinutes >= 2)
+            _lastTwoMinutes.Dequeue();
+    }
+}

--- a/src/WebApp/Controllers/ApiController.cs
+++ b/src/WebApp/Controllers/ApiController.cs
@@ -90,6 +90,12 @@ public class ApiController : ControllerBase
                         double kp = teamKills > 0 ? (kills + assists) / teamKills * 100.0 : 0.0;
                         double dmgPerMin = p.GetProperty("totalDamageDealtToChampions").GetInt32() / (timePlayed / 60.0);
                         double goldPerMin = p.GetProperty("goldEarned").GetInt32() / (timePlayed / 60.0);
+                        double score =
+                            Math.Min(kda / 5.0, 1.0) * 4 +
+                            Math.Min(csPerMin / 10.0, 1.0) * 2 +
+                            (kp / 100.0) * 2 +
+                            Math.Min(dmgPerMin / 1000.0, 1.0) * 2;
+                        score = Math.Round(Math.Min(score, 10.0), 1);
                         matches.Add(new
                         {
                             match_id = id,
@@ -103,7 +109,8 @@ public class ApiController : ControllerBase
                             cs_per_min = Math.Round(csPerMin, 1),
                             kp = Math.Round(kp, 0),
                             dmg_per_min = Math.Round(dmgPerMin, 1),
-                            gold_per_min = Math.Round(goldPerMin, 1)
+                            gold_per_min = Math.Round(goldPerMin, 1),
+                            score
                         });
                         break;
                     }

--- a/src/WebApp/wwwroot/script.js
+++ b/src/WebApp/wwwroot/script.js
@@ -5,6 +5,15 @@ const itemBase = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/
 const queueNames = { 420: 'Ranked Solo/Duo', 440: 'Ranked Flex', 400: 'Draft Pick', 430: 'Blind Pick', 450: 'ARAM' };
 let allMatches = [];
 
+function calcScore(kda, csPerMin, kp, dmgPerMin) {
+  let score = Math.min(kda / 5, 1) * 4 +
+              Math.min(csPerMin / 10, 1) * 2 +
+              (kp / 100) * 2 +
+              Math.min(dmgPerMin / 1000, 1) * 2;
+  score = Math.min(score, 10);
+  return score;
+}
+
 function displayScoreboard(data, region) {
   scoreboard.innerHTML = '';
   if (!data.info || !Array.isArray(data.info.participants)) {
@@ -30,14 +39,16 @@ function displayScoreboard(data, region) {
 
   Object.entries(teams).forEach(([teamId, players]) => {
     const header = document.createElement('h3');
-    header.textContent = teamId === '100' ? 'Blue Team' : 'Red Team';
+    const isBlue = teamId === '100';
+    header.textContent = isBlue ? 'Blue Team' : 'Red Team';
+    header.className = isBlue ? 'text-primary' : 'text-danger';
     scoreboard.appendChild(header);
 
     const table = document.createElement('table');
-    table.className = 'table table-custom table-striped mb-4';
+    table.className = `table table-custom table-striped mb-4 ${isBlue ? 'team-blue' : 'team-red'}`;
 
     const thead = document.createElement('thead');
-    thead.innerHTML = '<tr><th>Summoner</th><th>Champion</th><th>K / D / A</th><th>KDA</th><th>CS</th><th>CS/Min</th><th>KP%</th><th>DMG/Min</th><th>Items</th></tr>';
+    thead.innerHTML = '<tr><th>Summoner</th><th>Champion</th><th>K / D / A</th><th>KDA</th><th>CS</th><th>CS/Min</th><th>KP%</th><th>DMG/Min</th><th>Score</th><th>Items</th></tr>';
 
     table.appendChild(thead);
 
@@ -107,6 +118,11 @@ function displayScoreboard(data, region) {
       dmgTd.textContent = dmgPerMin.toFixed(1);
       row.appendChild(dmgTd);
 
+      const scoreTd = document.createElement('td');
+      const score = calcScore(parseFloat(ratio), csPerMin, kp, dmgPerMin);
+      scoreTd.textContent = score.toFixed(1);
+      row.appendChild(scoreTd);
+
       // Items column
       const itemsTd = document.createElement('td');
       const items = [p.item0, p.item1, p.item2, p.item3, p.item4, p.item5];
@@ -168,7 +184,7 @@ function renderMatches(matches, region) {
 
   const table = document.createElement('table');
   table.className = 'table table-custom table-striped';
-  table.innerHTML = '<thead><tr><th>Match ID</th><th>Champion</th><th>K / D / A</th><th>KDA</th><th>CS</th><th>CS/Min</th><th>KP%</th><th>DMG/Min</th><th>Result</th></tr></thead>';
+  table.innerHTML = '<thead><tr><th>Match ID</th><th>Champion</th><th>K / D / A</th><th>KDA</th><th>CS</th><th>CS/Min</th><th>KP%</th><th>DMG/Min</th><th>Score</th><th>Result</th></tr></thead>';
 
   const tbody = document.createElement('tbody');
   matches.forEach(m => {
@@ -214,6 +230,10 @@ function renderMatches(matches, region) {
     const dmgTd = document.createElement('td');
     dmgTd.textContent = m.dmg_per_min.toFixed(1);
     row.appendChild(dmgTd);
+
+    const scoreTd = document.createElement('td');
+    scoreTd.textContent = m.score.toFixed(1);
+    row.appendChild(scoreTd);
 
     const resultTd = document.createElement('td');
     resultTd.textContent = m.win ? 'Win' : 'Loss';

--- a/src/WebApp/wwwroot/style.css
+++ b/src/WebApp/wwwroot/style.css
@@ -50,3 +50,19 @@ pre {
   height: 24px;
   border-radius: 2px;
 }
+
+.team-blue thead {
+  background-color: #cfe2ff;
+}
+
+.team-red thead {
+  background-color: #f8d7da;
+}
+
+.team-blue tbody tr:nth-child(even) {
+  background-color: #e7f1ff;
+}
+
+.team-red tbody tr:nth-child(even) {
+  background-color: #ffe7e7;
+}


### PR DESCRIPTION
## Summary
- enforce Riot API rate limits with a simple RateLimiter
- colour team headers and tables based on side
- compute performance score for each player
- display the score in match and player tables

## Testing
- `dotnet build src/WebApp/WebApp.csproj` *(fails: `dotnet` not found)*